### PR TITLE
Experiment with rxjs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,13 @@
     "browser": true
   },
   "rules": {
+    "arrow-parens": [
+      2,
+      "as-needed",
+      {
+        "requireForBlockBody": true
+      }
+    ],
     "import/no-unresolved": "off",
     "import/prefer-default-export": "off",
     "object-curly-newline": "off",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "test": "elm-test --compiler ./node_modules/.bin/elm tests/Elm/**/*.elm",
     "tdd": "elm-test --compiler ./node_modules/.bin/elm tests/Elm/**/*.elm --watch"
   },
-  "dependencies": {},
+  "dependencies": {
+    "rxjs": "^6.4.0"
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.5.0",
     "@typescript-eslint/parser": "^2.5.0",

--- a/src/elm/Js.elm
+++ b/src/elm/Js.elm
@@ -1,5 +1,5 @@
 port module Js exposing
-    ( log, store
+    ( load, log, store
     , Message(..), receive
     )
 
@@ -13,7 +13,7 @@ through the `receive` subscription.
 
 # To JS
 
-@docs log, store
+@docs load, log, store
 
 
 # From JS
@@ -28,6 +28,14 @@ import Json.Encode as Encode exposing (Value)
 
 
 -- To JS
+
+
+{-| Ask JS to load dynamic libraries
+-}
+load : () -> Cmd msg
+load _ =
+    ToJS "load" Encode.null
+        |> command
 
 
 {-| Ask JS to console.log a String

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -3,6 +3,7 @@ module Main exposing (main)
 import Browser
 import Html exposing (Html)
 import Html.Attributes
+import Html.Events
 import Js exposing (Message(..))
 
 
@@ -49,12 +50,16 @@ init str =
 
 
 type Msg
-    = Received Message
+    = Load
+    | Received Message
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
+        Load ->
+            ( model, Js.load () )
+
         Received (Tick n) ->
             ( model, Js.store n )
 
@@ -74,6 +79,11 @@ subscriptions _ =
 view : Model -> Html Msg
 view model =
     Html.div
-        [ Html.Attributes.class "main" ]
-        [ Html.text model.content
+        [ Html.Attributes.class "elm" ]
+        [ Html.h1
+            []
+            [ Html.text model.content ]
+        , Html.button
+            [ Html.Events.onClick Load ]
+            [ Html.text "Trigger Storage" ]
         ]

--- a/src/elm/Main/index.d.ts
+++ b/src/elm/Main/index.d.ts
@@ -81,7 +81,7 @@ export type Ports = {
 }
 
 /** Type of commands coming from Elm to perform on the JS side. */
-export type Action = LogAction | StoreAction;
+export type Action = LoadAction | LogAction | StoreAction;
 
 /** Type of messages to send from JS to notify the Elm side. */
 export type Message = TickMessage;
@@ -95,6 +95,11 @@ export type Cmd<T> = {
 /** API for outgoing ports to Elm */
 export type Sub<T> = {
   send(value: T): void;
+}
+
+export type LoadAction = {
+  readonly kind: 'load';
+  readonly value: null;
 }
 
 export type LogAction = {

--- a/src/lib/elm.ts
+++ b/src/lib/elm.ts
@@ -5,7 +5,36 @@ export function initializeElmApp(node: Element | null, flags: Flags): App {
   return Elm.Main.init({ node, flags });
 }
 
-export function dispatch(app: App) {
+export function sendTick(app: App, tick: number): void {
+  const tickMsg: TickMessage = {
+    kind: 'tick',
+    value: tick,
+  };
+
+  app.ports.notification.send(tickMsg);
+}
+
+async function load(app: App): Promise<void> {
+  const { interval, filter, map, tap } = await import('./rxjs');
+
+  interval(100)
+    .pipe(
+      map(n => n * 10),
+      tap(n => console.log(n)),
+      filter(n => n % 100 === 0),
+    )
+    .subscribe(n => sendTick(app, n));
+}
+
+function log(value: string): void {
+  console.log(value);
+}
+
+function store(value: number): void {
+  console.log(`Storing value: ${value}`);
+}
+
+export function dispatch(app: App): void {
   app.ports.command.subscribe((action) => {
     switch (action.kind) {
       case 'load':
@@ -18,33 +47,4 @@ export function dispatch(app: App) {
         return assertNever(action);
     }
   });
-}
-
-export function sendTick(app: App, tick: number): void {
-  const tickMsg: TickMessage = {
-    kind: 'tick',
-    value: tick,
-  };
-
-  app.ports.notification.send(tickMsg);
-}
-
-async function load(app: App) {
-  const { interval, filter, map, tap } = await import('./rxjs');
-
-  interval(100)
-    .pipe(
-      map(n => n * 10),
-      tap(n => console.log(n)),
-      filter(n => n % 100 === 0),
-    )
-    .subscribe(n => sendTick(app, n));
-}
-
-function log(value: string) {
-  console.log(value);
-}
-
-function store(value: number) {
-  console.log(`Storing value: ${value}`);
 }

--- a/src/lib/elm.ts
+++ b/src/lib/elm.ts
@@ -1,4 +1,4 @@
-import { Action, App, Elm, Flags, TickMessage } from '../elm/Main';
+import { App, Elm, Flags, TickMessage } from '../elm/Main';
 import { assertNever } from './utils';
 
 export function initializeElmApp(node: Element | null, flags: Flags): App {
@@ -6,7 +6,7 @@ export function initializeElmApp(node: Element | null, flags: Flags): App {
 }
 
 export function dispatch(app: App) {
-  return function (action: Action) {
+  app.ports.command.subscribe((action) => {
     switch (action.kind) {
       case 'load':
         return load(app);
@@ -17,7 +17,7 @@ export function dispatch(app: App) {
       default:
         return assertNever(action);
     }
-  };
+  });
 }
 
 export function sendTick(app: App, tick: number): void {

--- a/src/lib/elm.ts
+++ b/src/lib/elm.ts
@@ -5,23 +5,19 @@ export function initializeElmApp(node: Element | null, flags: Flags): App {
   return Elm.Main.init({ node, flags });
 }
 
-function log(value: string): void {
-  console.log(value);
-}
-
-function store(value: number): void {
-  console.log(`Storing value: ${value}`);
-}
-
-export function dispatch(action: Action): void {
-  switch (action.kind) {
-    case 'log':
-      return log(action.value);
-    case 'store':
-      return store(action.value);
-    default:
-      return assertNever(action);
-  }
+export function dispatch(app: App) {
+  return function (action: Action) {
+    switch (action.kind) {
+      case 'load':
+        return load(app);
+      case 'log':
+        return log(action.value);
+      case 'store':
+        return store(action.value);
+      default:
+        return assertNever(action);
+    }
+  };
 }
 
 export function sendTick(app: App, tick: number): void {
@@ -31,4 +27,24 @@ export function sendTick(app: App, tick: number): void {
   };
 
   app.ports.notification.send(tickMsg);
+}
+
+async function load(app: App) {
+  const { interval, filter, map, tap } = await import('./rxjs');
+
+  interval(100)
+    .pipe(
+      map(n => n * 10),
+      tap(n => console.log(n)),
+      filter(n => n % 100 === 0),
+    )
+    .subscribe(n => sendTick(app, n));
+}
+
+function log(value: string) {
+  console.log(value);
+}
+
+function store(value: number) {
+  console.log(`Storing value: ${value}`);
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,5 @@
+import { interval } from 'rxjs';
+import { map, filter } from 'rxjs/operators';
 import { initializeElmApp, dispatch, sendTick } from './elm';
 
 const node = document.querySelector('#elm-root');
@@ -6,4 +8,11 @@ const app = initializeElmApp(node, 'Hello world! o/');
 
 app.ports.command.subscribe(dispatch);
 
-setTimeout(sendTick, 5000, app, 42);
+const seconds = interval(1000);
+
+seconds
+  .pipe(
+    map(n => n * 10),
+    filter(n => n % 100 === 0)
+  )
+  .subscribe(n => sendTick(app, n));

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -13,6 +13,6 @@ const seconds = interval(1000);
 seconds
   .pipe(
     map(n => n * 10),
-    filter(n => n % 100 === 0)
+    filter(n => n % 100 === 0),
   )
   .subscribe(n => sendTick(app, n));

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,4 +3,4 @@ import { initializeElmApp, dispatch } from './elm';
 const node = document.querySelector('#elm-root');
 const app = initializeElmApp(node, 'Hello world! o/');
 
-app.ports.command.subscribe(dispatch(app));
+dispatch(app);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,5 @@
 import { interval } from 'rxjs';
-import { map, filter } from 'rxjs/operators';
+import { map, filter, tap } from 'rxjs/operators';
 import { initializeElmApp, dispatch, sendTick } from './elm';
 
 const node = document.querySelector('#elm-root');
@@ -8,11 +8,10 @@ const app = initializeElmApp(node, 'Hello world! o/');
 
 app.ports.command.subscribe(dispatch);
 
-const seconds = interval(1000);
-
-seconds
+interval(100)
   .pipe(
     map(n => n * 10),
+    tap(console.log.bind(this)),
     filter(n => n % 100 === 0),
   )
   .subscribe(n => sendTick(app, n));

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,17 +1,6 @@
-import { interval } from 'rxjs';
-import { map, filter, tap } from 'rxjs/operators';
-import { initializeElmApp, dispatch, sendTick } from './elm';
+import { initializeElmApp, dispatch } from './elm';
 
 const node = document.querySelector('#elm-root');
-
 const app = initializeElmApp(node, 'Hello world! o/');
 
-app.ports.command.subscribe(dispatch);
-
-interval(100)
-  .pipe(
-    map(n => n * 10),
-    tap(console.log.bind(this)),
-    filter(n => n % 100 === 0),
-  )
-  .subscribe(n => sendTick(app, n));
+app.ports.command.subscribe(dispatch(app));

--- a/src/lib/rxjs.ts
+++ b/src/lib/rxjs.ts
@@ -1,0 +1,2 @@
+export { interval } from 'rxjs';
+export { filter, map, tap } from 'rxjs/operators';

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -1,11 +1,19 @@
 @import url('https://fonts.googleapis.com/css?family=Roboto');
 
 body {
-  font-family: 'Roboto', sans-serif;
   background-color: rgb(40, 44, 52);
-  color: rgb(163, 162, 171);
 }
 
-.main {
-  font-size: 36px;
+.elm {
+  color: rgb(163, 162, 171);
+  font-family: 'Roboto', sans-serif;
+}
+
+button {
+  background-color: rebeccapurple;
+  border-width: 0;
+  border-radius: 5px;
+  color: cornflowerblue;
+  font-size: 16px;
+  padding: 8px;
 }


### PR DESCRIPTION
Just experimenting with `rxjs` streams on the TS side, mostly to see if the additional dependency explodes the bundle size.

As a matter of fact, it did go from ~19kB without it to ~246kB with it which uncovered the fact that parcel did not perform tree-shaking out of the box.
Hence the addition of the `--experimental-scope-hoisting` flag in commit 9dbf8f0.

Bundle size is now ~18kB without rxjs and ~30kB with it which seem much more reasonable but still a bit large to pull that dependency while not absolutely necessary.

Keeping this PR here as a reference in the meantime though.